### PR TITLE
Change freezer to skip copying specific types

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 9
-total_score: 61
+total_score: 66

--- a/config/site.reek
+++ b/config/site.reek
@@ -75,7 +75,8 @@ UncommunicativeVariableName:
   - !ruby/regexp /[0-9]$/
   - !ruby/regexp /[A-Z]/
 SimulatedPolymorphism:
-  exclude: []
+  exclude:
+  - Adamantium::Freezer  # TODO: figure out how to remove extra tests on object
   enabled: true
   max_ifs: 1
 DataClump:

--- a/lib/adamantium/freezer.rb
+++ b/lib/adamantium/freezer.rb
@@ -56,7 +56,7 @@ module Adamantium
     #   an object to copy
     #
     # @return [Object]
-    #   if it can be copied return one, otherwise return the object as-is
+    #   if it can be copied return a copy, otherwise return the object as-is
     #
     # @api private
     def self.copy_object(object)

--- a/lib/adamantium/freezer.rb
+++ b/lib/adamantium/freezer.rb
@@ -18,14 +18,11 @@ module Adamantium
       Method,
     ].freeze
 
-    # A list of types that should not be copied
-    NO_COPY = [
+    # A list of types that should not be frozen
+    NO_FREEZE = [
       Class,
       Module,
     ].freeze
-
-    # A list of types that will not be copied
-    SKIP_COPY = (NOT_COPYABLE | NO_COPY).freeze
 
     private_class_method :new
 
@@ -45,7 +42,12 @@ module Adamantium
     #
     # @api public
     def self.call(object)
-      object.frozen? ? object : freeze(copy_object(object))
+      case object
+      when *NO_FREEZE
+        object
+      else
+        object.frozen? ? object : freeze(copy_object(object))
+      end
     end
 
     private_class_method :call
@@ -61,7 +63,7 @@ module Adamantium
     # @api private
     def self.copy_object(object)
       case object
-      when *SKIP_COPY
+      when *NOT_COPYABLE
         object
       else
         object.dup

--- a/lib/adamantium/freezer.rb
+++ b/lib/adamantium/freezer.rb
@@ -7,21 +7,23 @@ module Adamantium
   # Better pattern for singleton inheritance/shared code
   class Freezer
 
-    # A list of types that cannot be copied
+    # A list of types that should not be frozen
+    NOT_FREEZABLE = [
+      Class,
+      Module,
+    ].freeze
+
+    # A list of types that should not be copied
     NOT_COPYABLE = [
       Numeric,
       TrueClass,
       FalseClass,
       NilClass,
       Symbol,
-      UnboundMethod,
-      Method,
-    ].freeze
-
-    # A list of types that should not be frozen
-    NO_FREEZE = [
       Class,
       Module,
+      UnboundMethod,
+      Method,
     ].freeze
 
     private_class_method :new
@@ -43,7 +45,7 @@ module Adamantium
     # @api public
     def self.call(object)
       case object
-      when *NO_FREEZE
+      when *NOT_FREEZABLE
         object
       else
         object.frozen? ? object : freeze(copy_object(object))

--- a/lib/adamantium/freezer.rb
+++ b/lib/adamantium/freezer.rb
@@ -7,6 +7,26 @@ module Adamantium
   # Better pattern for singleton inheritance/shared code
   class Freezer
 
+    # A list of types that cannot be copied
+    NOT_COPYABLE = [
+      Numeric,
+      TrueClass,
+      FalseClass,
+      NilClass,
+      Symbol,
+      UnboundMethod,
+      Method,
+    ].freeze
+
+    # A list of types that should not be copied
+    NO_COPY = [
+      Class,
+      Module,
+    ].freeze
+
+    # A list of types that will not be copied
+    SKIP_COPY = (NOT_COPYABLE | NO_COPY).freeze
+
     private_class_method :new
 
     # Attempt to freeze an object
@@ -25,30 +45,30 @@ module Adamantium
     #
     # @api public
     def self.call(object)
-      case object
-      when Numeric, TrueClass, FalseClass, NilClass, Symbol, Class, Module, UnboundMethod, Method
-        object
-      else
-        freeze_value(object)
-      end
+      object.frozen? ? object : freeze(copy_object(object))
     end
 
     private_class_method :call
 
-    # Returns a frozen value
+    # Return a copy of an object if possible
     #
-    # @param [Object] value
-    #   a value to freeze
+    # @param [Object] object
+    #   an object to copy
     #
     # @return [Object]
-    #   if frozen, the value directly, otherwise a frozen copy of the value
+    #   if it can be copied return one, otherwise return the object as-is
     #
     # @api private
-    def self.freeze_value(value)
-      value.frozen? ? value : freeze(value.dup)
+    def self.copy_object(object)
+      case object
+      when *SKIP_COPY
+        object
+      else
+        object.dup
+      end
     end
 
-    private_class_method :freeze_value
+    private_class_method :copy_object
 
     # Freezer that does not deep freeze
     class Flat < self

--- a/spec/unit/adamantium/freezer/deep/class_methods/call_spec.rb
+++ b/spec/unit/adamantium/freezer/deep/class_methods/call_spec.rb
@@ -11,36 +11,48 @@ describe Adamantium::Freezer::Deep, '.call' do
     let(:value) { 1 }
 
     it { should equal(value) }
+
+    it { should_not be_frozen }
   end
 
   context 'with a true value' do
     let(:value) { true }
 
     it { should equal(value) }
+
+    it { should_not be_frozen }
   end
 
   context 'with a false value' do
     let(:value) { false }
 
     it { should equal(value) }
+
+    it { should_not be_frozen }
   end
 
   context 'with a nil value' do
     let(:value) { nil }
 
     it { should equal(value) }
+
+    it { should_not be_frozen }
   end
 
   context 'with a symbol value' do
     let(:value) { :symbol }
 
     it { should equal(value) }
+
+    it { should_not be_frozen }
   end
 
   context 'with a frozen value' do
     let(:value) { String.new.freeze }
 
     it { should equal(value) }
+
+    it { should be_frozen }
   end
 
   context 'with a method value' do
@@ -48,7 +60,7 @@ describe Adamantium::Freezer::Deep, '.call' do
 
     it { should equal(value) }
 
-    it { should_not be_frozen }
+    it { should be_frozen }
   end
 
   context 'with a unbound method value' do
@@ -56,7 +68,7 @@ describe Adamantium::Freezer::Deep, '.call' do
 
     it { should equal(value) }
 
-    it { should_not be_frozen }
+    it { should be_frozen }
   end
 
   context 'with a module value' do
@@ -64,7 +76,7 @@ describe Adamantium::Freezer::Deep, '.call' do
 
     it { should equal(value) }
 
-    it { should_not be_frozen }
+    it { should be_frozen }
   end
 
   context 'with a class value' do
@@ -72,7 +84,7 @@ describe Adamantium::Freezer::Deep, '.call' do
 
     it { should equal(value) }
 
-    it { should_not be_frozen }
+    it { should be_frozen }
   end
 
   context 'with an unfrozen value' do
@@ -80,9 +92,7 @@ describe Adamantium::Freezer::Deep, '.call' do
 
     it { should_not equal(value) }
 
-    it { should be_instance_of(String) }
-
-    it { should == value }
+    it { should eql(value) }
 
     it { should be_frozen }
   end
@@ -93,5 +103,11 @@ describe Adamantium::Freezer::Deep, '.call' do
     it 'does freeze inner values' do
       subject.first.should be_frozen
     end
+
+    it { should_not equal(value) }
+
+    it { should eql(value) }
+
+    it { should be_frozen }
   end
 end

--- a/spec/unit/adamantium/freezer/deep/class_methods/call_spec.rb
+++ b/spec/unit/adamantium/freezer/deep/class_methods/call_spec.rb
@@ -76,7 +76,7 @@ describe Adamantium::Freezer::Deep, '.call' do
 
     it { should equal(value) }
 
-    it { should be_frozen }
+    it { should_not be_frozen }
   end
 
   context 'with a class value' do
@@ -84,7 +84,7 @@ describe Adamantium::Freezer::Deep, '.call' do
 
     it { should equal(value) }
 
-    it { should be_frozen }
+    it { should_not be_frozen }
   end
 
   context 'with an unfrozen value' do


### PR DESCRIPTION
- The previous code skipped freezing and copying, when in fact it is
  still valid to freeze some kinds of objects, but not dup them.
- This is probably not ready because I think @mbj will want to
  object to having Class and Module frozen like this. We will need
  to come up with a solution, whether it's something specific to
  Adamantium or even in IceNine, I'm not sure. Although I assume the
  former, since I'm not sure if it'd be a good idea to have IceNine
  skip freezing Class and Module instances globally since there are
  valid use cases where you would want this to happen.
