### PR TITLE
Do not allow memoization methods with nonzero arity

### DIFF
--- a/lib/adamantium/module_methods.rb
+++ b/lib/adamantium/module_methods.rb
@@ -59,7 +59,7 @@ module Adamantium
     def memoize_method(method_name, freezer)
       method = instance_method(method_name)
       unless method.arity.zero?
-        raise ArgumentError, 'Cannot memoize method with unzero arity'
+        raise ArgumentError, 'Cannot memoize method with nonzero arity'
       end
       visibility = method_visibility(method_name)
       define_memoize_method(method, freezer)

--- a/lib/adamantium/module_methods.rb
+++ b/lib/adamantium/module_methods.rb
@@ -48,24 +48,28 @@ module Adamantium
 
     # Memoize the named method
     #
-    # @param [#to_s] method
-    #   a method to memoize
+    # @param [#to_s] method_name
+    #   a method name to memoize
     # @param [#call] freezer
     #   a freezer for memoized values
     #
     # @return [undefined]
     #
     # @api private
-    def memoize_method(method, freezer)
-      visibility = method_visibility(method)
+    def memoize_method(method_name, freezer)
+      method = instance_method(method_name)
+      unless method.arity.zero?
+        raise ArgumentError, 'Cannot memoize method with unzero arity'
+      end
+      visibility = method_visibility(method_name)
       define_memoize_method(method, freezer)
-      send(visibility, method)
+      send(visibility, method_name)
     end
 
     # Define a memoized method that delegates to the original method
     #
-    # @param [Symbol] method
-    #   the name of the method
+    # @param [UnboundMethod] method
+    #   the method to memoize
     # @param [#call] freezer
     #   a freezer for memoized values
     #
@@ -73,13 +77,13 @@ module Adamantium
     #
     # @api private
     def define_memoize_method(method, freezer)
-      original = instance_method(method)
-      undef_method(method)
-      define_method(method) do |*args|
-        memory.fetch(method) do
-          value  = original.bind(self).call(*args)
+      method_name = method.name
+      undef_method(method_name)
+      define_method(method_name) do |*args|
+        memory.fetch(method_name) do
+          value  = method.bind(self).call(*args)
           frozen = freezer.call(value)
-          store_memory(method, frozen)
+          store_memory(method_name, frozen)
         end
       end
     end

--- a/lib/adamantium/module_methods.rb
+++ b/lib/adamantium/module_methods.rb
@@ -58,7 +58,7 @@ module Adamantium
     # @api private
     def memoize_method(method_name, freezer)
       method = instance_method(method_name)
-      unless method.arity.zero?
+      if method.arity.nonzero?
         raise ArgumentError, 'Cannot memoize method with nonzero arity'
       end
       visibility = method_visibility(method_name)

--- a/lib/adamantium/module_methods.rb
+++ b/lib/adamantium/module_methods.rb
@@ -77,7 +77,7 @@ module Adamantium
     #
     # @api private
     def define_memoize_method(method, freezer)
-      method_name = method.name
+      method_name = method.name.to_sym
       undef_method(method_name)
       define_method(method_name) do |*args|
         memory.fetch(method_name) do

--- a/spec/unit/adamantium/fixtures/classes.rb
+++ b/spec/unit/adamantium/fixtures/classes.rb
@@ -4,6 +4,9 @@ module AdamantiumSpecs
   class Object
     include Adamantium
 
+    def argumented(foo)
+    end
+
     def test
       'test'
     end

--- a/spec/unit/adamantium/module_methods/memoize_spec.rb
+++ b/spec/unit/adamantium/module_methods/memoize_spec.rb
@@ -23,7 +23,7 @@ shared_examples_for 'memoizes method' do
     if method != :some_state
       file, line = object.new.send(method).first.split(':')[0, 2]
       File.expand_path(file).should eql(File.expand_path('../../../../../lib/adamantium/module_methods.rb', __FILE__))
-      line.to_i.should eql(80)
+      line.to_i.should eql(84)
     end
   end
 
@@ -67,6 +67,14 @@ describe Adamantium::ModuleMethods, '#memoize' do
       def some_state
         Object.new
       end
+    end
+  end
+  
+  context 'on method with arguments' do
+    let(:method) { :argumented }
+
+    it 'should raise error' do
+      expect { subject }.to raise_error(ArgumentError, 'Cannot memoize method with unzero arity')
     end
   end
 

--- a/spec/unit/adamantium/module_methods/memoize_spec.rb
+++ b/spec/unit/adamantium/module_methods/memoize_spec.rb
@@ -74,7 +74,7 @@ describe Adamantium::ModuleMethods, '#memoize' do
     let(:method) { :argumented }
 
     it 'should raise error' do
-      expect { subject }.to raise_error(ArgumentError, 'Cannot memoize method with unzero arity')
+      expect { subject }.to raise_error(ArgumentError, 'Cannot memoize method with nonzero arity')
     end
   end
 


### PR DESCRIPTION
This makes sure the memoizer is not used to create tricky to track down
bugs.

Currently adamantium allows the following:

```
class Foo
  include Adamantium

  def something(x)
    x * 2
  end
  memoize :something
end

foo = Foo.new
foo.something(1) # => 2
foo.something(2) # => 2, Tricky to track down bug.
```
