### PR TITLE
Fix memoized method proxy arity.

### DIFF
--- a/lib/adamantium/module_methods.rb
+++ b/lib/adamantium/module_methods.rb
@@ -79,9 +79,9 @@ module Adamantium
     def define_memoize_method(method, freezer)
       method_name = method.name.to_sym
       undef_method(method_name)
-      define_method(method_name) do |*args|
+      define_method(method_name) do 
         memory.fetch(method_name) do
-          value  = method.bind(self).call(*args)
+          value  = method.bind(self).call
           frozen = freezer.call(value)
           store_memory(method_name, frozen)
         end


### PR DESCRIPTION
We only allow memoization of zero arity methods, so this argument
proxying is not needed at all.

Will merge it in once CI reports green.
