### PR TITLE
Original source location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
   - rbx-18mode
   - rbx-19mode
 matrix:
-  allowed_failures:
+  allow_failures:
     - rvm: ruby-head
 notifications:
   irc: "irc.freenode.org#datamapper"

--- a/lib/adamantium/module_methods.rb
+++ b/lib/adamantium/module_methods.rb
@@ -88,6 +88,10 @@ module Adamantium
           store_memory(method_name, frozen)
         end
       end
+
+      define_method("#{method_name}_original_source_location") do
+        method.source_location
+      end
     end
 
     # Return the method visibility of a method


### PR DESCRIPTION
Mutant needs the original source location to identify methods AST.

The acutal implementation redefines the method via `define_method` so the original source location is lost.
