### PR TITLE
Add Adamantium::Mutable

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 7
-total_score: 53
+total_score: 56

--- a/lib/adamantium.rb
+++ b/lib/adamantium.rb
@@ -164,3 +164,4 @@ end # module Adamantium
 require 'adamantium/module_methods'
 require 'adamantium/class_methods'
 require 'adamantium/freezer'
+require 'adamantium/mutable'

--- a/lib/adamantium/mutable.rb
+++ b/lib/adamantium/mutable.rb
@@ -1,4 +1,16 @@
 module Adamantium
+
+  # Module fake frozen object
+  #
+  # This behavior sometimes is needed when a mutable
+  # object needs to be referenced in an inmutable object tree.
+  #
+  # If you have to use `memoize :foo, :freezer => :noop` to often you might
+  # want to include this module into your class.
+  #
+  # Use wisely! A rule of thumb only a tiny fraction of your objects
+  # typically deserves this.
+  #
   module Mutable
 
     # Noop freezer

--- a/lib/adamantium/mutable.rb
+++ b/lib/adamantium/mutable.rb
@@ -1,0 +1,41 @@
+module Adamantium
+  module Mutable
+
+    # Noop freezer
+    #
+    # @example
+    #   class DoesNotGetFrozen
+    #     include Adamantium::Mutable
+    #   end
+    #
+    #   instance = DoesNotGetFrozen
+    #   instance.freeze # => instance
+    #
+    # @return [self]
+    #
+    # @api public
+    #
+    def freeze
+      self
+    end
+
+    # Test if object is frozen
+    #
+    # @example
+    #   class DoesNotGetFrozen
+    #     include Adamantium::Mutable
+    #   end
+    #
+    #   instance = DoesNotGetFrozen
+    #   instance.frozen? # => true
+    #
+    # @return [true]
+    #
+    # @api public
+    #
+    def frozen?
+      true
+    end
+
+  end # Mutable
+end # Adamantium

--- a/spec/unit/adamantium/mutable/freeze_spec.rb
+++ b/spec/unit/adamantium/mutable/freeze_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Adamantium::Mutable, '#freeze' do
+  subject { object.freeze }
+
+  let(:object) { class_under_test.new }
+
+  let(:class_under_test) do
+    Class.new do
+      include Adamantium::Mutable
+    end
+  end
+
+  it_should_behave_like 'a command method'
+
+  it 'keeps object mutable' do
+    subject
+    object.instance_variable_set(:@foo, :bar)
+  end
+end
+

--- a/spec/unit/adamantium/mutable/frozen_predicate_spec.rb
+++ b/spec/unit/adamantium/mutable/frozen_predicate_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Adamantium::Mutable, '#frozen?' do
+  subject { object.frozen? }
+
+  let(:object) { class_under_test.new }
+
+  let(:class_under_test) do
+    Class.new do
+      include Adamantium::Mutable
+    end
+  end
+
+  it { should be(true) }
+
+  it_should_behave_like 'an idempotent method'
+end


### PR DESCRIPTION
Rationale:

Sometimes an object _must_ be mutable. But it can end up in a frozen
object tree. Instead of using `memoize :foo, :freezer => :noop` the
object itself could make sure it does not _really_ get frozen.

Use. With. Care.
