### PR TITLE
Doc tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,12 @@ class FlatExample
   include Adamantium::Flat
 
   # Instance is frozen but attribute is not
+  # Example:
+  #
   # object = FlatExample.new
   # object.frozen?           # => true
   # object.attribute.frozen? # => false
+  #
   def initialize
     @attribute = "foo bar"
   end

--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ class Example
     [SecureRandom.hex(6)]
   end
   memoize :random2, freezer: :flat
+
+  # Transform method derives changed instances without
+  # calling the constructor
+  # Example:
+  #
+  # object = Example.new
+  # object.random => ["abcdef"]
+  # update = object.edit "baz quux"
+  # update.random => ["abcdef"]
+  # update.attribute => "baz quux"
+  #
+  def edit attribute
+    transform do
+      @attribute = attribute
+    end
+  end
 end
 
 class FlatExample


### PR DESCRIPTION
I've enjoyed using the Adamantium gem a few months and happened to see "transform" mentioned in a set of slides. I thought it was something the speaker wrote, until I poked around in the code and found it. So I've added a quick doc in the style of the existing examples.

I also a made a very small style tweak to bring another example in line with all the rest.

No code changes.
