### PR TITLE
Adds spec for issue with memoization and dynamic methods

### DIFF
--- a/spec/unit/adamantium/dynamic_methods_memoize_spec.rb
+++ b/spec/unit/adamantium/dynamic_methods_memoize_spec.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Adamantium, 'memoizing methods that initialize objects with dynamically defined methods' do
+  let(:component_class) {
+    Class.new do
+      def initialize(attributes)
+        attributes.each do |key, value|
+          instance_variable_set("@#{key}".to_sym, value)
+          define_singleton_method(key) { instance_variable_get("@#{key}") }
+        end
+      end
+    end
+  }
+
+  context 'a component instance' do
+    subject { component_class.new(test: true) }
+
+    it      { is_expected.to respond_to(:test) }
+    specify { expect(subject.test).to eq true }
+  end
+
+  context 'a composed instance' do
+    before do
+      stub_const('Component', component_class)
+    end
+
+    let(:composed_class) {
+      Class.new do
+        include Adamantium
+
+        def component
+          Component.new(test: true)
+        end
+
+        memoize :component
+      end
+    }
+
+    let(:composed) { composed_class.new }
+
+    context 'its composed' do
+      subject { composed.component }
+
+      it      { is_expected.to be_a component_class }
+      it      { is_expected.to respond_to(:test) }
+      specify { expect(subject.test).to eq true }
+    end
+  end
+end


### PR DESCRIPTION
Hi @dkubb ,

I think I might have found an issue with memoization.

Apparently, when memoizing a method which initialises objects that define methods dynamically, the dynamic methods on the object are no longer public.

Please see the spec I added to replicate the problem.

When running the spec, this is the output I get (stripped of non relevant lines):

```
bundle exec rspec spec/unit/adamantium/dynamic_methods_memoize_spec.rb 

FF...

Failures:

  1) Adamantium memoizing methods that initialize objects with dynamically defined methods a composed instance its composed should respond to #test
     Failure/Error: it      { is_expected.to respond_to(:test) }
       expected #<Component:0x007f85f399b5a8 @test=true> to respond to :test
     # ./spec/unit/adamantium/dynamic_methods_memoize_spec.rb:47:in `block (4 levels) in <top (required)>'
     # ./vendor/ruby/2.2.0/bundler/gems/devtools-8d492930b9a5/lib/devtools/project/initializer/rspec.rb:48:in `block in enable_unit_test_timeout'

  2) Adamantium memoizing methods that initialize objects with dynamically defined methods a composed instance its composed 
     Failure/Error: specify { expect(subject.test).to eq true }

     NoMethodError:
       private method `test' called for #<Component:0x007f85f1283f88 @test=true>
     # ./spec/unit/adamantium/dynamic_methods_memoize_spec.rb:48:in `block (4 levels) in <top (required)>'
     # ./vendor/ruby/2.2.0/bundler/gems/devtools-8d492930b9a5/lib/devtools/project/initializer/rspec.rb:48:in `block in enable_unit_test_timeout'

Finished in 0.01913 seconds (files took 0.46045 seconds to load)
5 examples, 2 failures

Failed examples:

rspec ./spec/unit/adamantium/dynamic_methods_memoize_spec.rb:47 # Adamantium memoizing methods that initialize objects with dynamically defined methods a composed instance its composed should respond to #test
rspec ./spec/unit/adamantium/dynamic_methods_memoize_spec.rb:48 # Adamantium memoizing methods that initialize objects with dynamically defined methods a composed instance its composed 
```

I apologise for not having provided a solution, unfortunately I do not have the time to investigate the issue any further at this moment, but I hope that the spec I provided might help you investigate the issue for future releases.
