### PR TITLE
Update Memoizable dependency and add `Adamantium::ModuleMethods#memoized`?

### DIFF
--- a/adamantium.gemspec
+++ b/adamantium.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('ice_nine',   '~> 0.11.0')
   gem.add_runtime_dependency('memoizable', '~> 0.4.2')
 
-  gem.add_development_dependency('bundler', '~> 1.6', '>= 1.6.5')
+  gem.add_development_dependency('bundler', '>= 1.6.5')
 end

--- a/adamantium.gemspec
+++ b/adamantium.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[LICENSE README.md CONTRIBUTING.md TODO]
 
   gem.add_runtime_dependency('ice_nine',   '~> 0.11.0')
-  gem.add_runtime_dependency('memoizable', '~> 0.4.2')
+  gem.add_runtime_dependency('memoizable', '~> 0.5.1')
 
   gem.add_development_dependency('bundler', '>= 1.6.5')
 end

--- a/lib/adamantium/module_methods.rb
+++ b/lib/adamantium/module_methods.rb
@@ -14,6 +14,21 @@ module Adamantium
       Freezer::Deep
     end
 
+    # Check if a method is memoized
+    #
+    # @example
+    #   class.memoized?(:hash)
+    #
+    # @param [Symbol] method_name
+    #   a method name to check
+    #
+    # @return [Boolean]
+    #
+    # @api public
+    def memoized?(method_name)
+      memoized_methods.key?(method_name)
+    end
+
     # Memoize a list of methods
     #
     # @example


### PR DESCRIPTION
Adamantium delegated to Memoizable’s `memoized?` method, but this was a private API that was removed in https://github.com/dkubb/memoizable/commit/bd7a84aade04f99547204e365de77b942c1dac76, so I've explicitly defined it here to be part of Adamantium’s public API, since it’s used externally by Mutant to detect memoized instance methods.